### PR TITLE
Fix unit test

### DIFF
--- a/python/bls_pulse_vec.py
+++ b/python/bls_pulse_vec.py
@@ -53,15 +53,13 @@ def compute_signal_residual(binned_segment, matrix, duration, n_bins_min_duratio
     s = reindex_to_matrix(binned_segment_indexed.flux, matrix).cumsum(axis=1)
     n = binned_segment_indexed.samples.sum()
     sr = s**2 / (r * (n - r))
-    ## This is the product of the direction times the "s" value, used later to compare that the best SR matches the desired direction.
-    ds = direction * s
 
     sr[:,duration <= n_bins_min_duration] = np.nan
     SR_index = np.unravel_index(np.ma.masked_invalid(sr).argmax(), sr.shape)
     i1 = int(SR_index[0])
     i2 = int(matrix[SR_index])
     ## Make sure the best SR matches the desired direction.
-    if ds[SR_index] >= 0:
+    if s[SR_index]*direction >= 0:
         return pd.Series(dict(
                 phases=i1,
                 durations=binned_segment_indexed.samples[i1:i2].sum(),

--- a/python/sim_lc/test_bls_pulse.py
+++ b/python/sim_lc/test_bls_pulse.py
@@ -123,10 +123,18 @@ def main():
                     print "   Transit {0: <3d}.....PASS".format(tnum)
                 else:
                     err_string_to_add = ""
-                    if abs(ttime-these_srs["midtimes"].values[closest_index]) <= midtime_precision_threshold: err_string_to_add += " (timestamp)"
-                    if abs(tdepth-these_srs["depths"].values[closest_index])/tdepth <= depth_rel_precision_threshold: err_string_to_add += " (depth)"
-                    if abs(tduration-these_srs["durations"].values[closest_index])/tduration <= duration_rel_precision_threshold: err_string_to_add += " (duration)"
+                    err_string_line2 = ""
+                    if abs(ttime-these_srs["midtimes"].values[closest_index]) >= midtime_precision_threshold:
+                        err_string_to_add += " (timestamp)"
+                        err_string_line2 += "\n\tTIMESTAMP: Expected: " + str(ttime) + " Measured: " + str(these_srs["midtimes"].values[closest_index]) + " Diff: " + str(abs(ttime-these_srs["midtimes"].values[closest_index])) + " Allowed Diff: " + str(midtime_precision_threshold)
+                    if abs(tdepth-these_srs["depths"].values[closest_index])/tdepth >= depth_rel_precision_threshold:
+                        err_string_to_add += " (depth)"
+                        err_string_line2 += "\n\tDEPTH: Expected: " + str(tdepth) + " Measured: " + str(these_srs["depths"].values[closest_index]) + " Rel. Diff: " + str(abs(tdepth-these_srs["depths"].values[closest_index])/tdepth*100.) + "% Allowed Rel. Diff: " + str(depth_rel_precision_threshold*100.)+"%"
+                    if abs(tduration-these_srs["durations"].values[closest_index])/tduration >= duration_rel_precision_threshold:
+                        err_string_to_add += " (duration)"
+                        err_string_line2 += "\n\tDURATION: Expected: " + str(tduration) + " Measured: " + str(these_srs["durations"].values[closest_index]) + " Rel. Diff: " + str(abs(tduration-these_srs["durations"].values[closest_index])/tduration*100.) + "% Allowed Rel. Diff: " + str(duration_rel_precision_threshold*100.)+"%"
                     print "   Transit {0: <3d}...FAIL".format(tnum) + err_string_to_add
+                    print err_string_line2
                     sys.exit(1)
 
 if __name__ == "__main__":

--- a/python/sim_lc/test_bls_pulse_vec.py
+++ b/python/sim_lc/test_bls_pulse_vec.py
@@ -116,10 +116,18 @@ def main():
                     print "   Transit {0: <3d}.....PASS".format(tnum)
                 else:
                     err_string_to_add = ""
-                    if abs(ttime-these_srs["midtimes"].values[closest_index]) <= midtime_precision_threshold: err_string_to_add += " (timestamp)"
-                    if abs(tdepth-these_srs["depths"].values[closest_index])/tdepth <= depth_rel_precision_threshold: err_string_to_add += " (depth)"
-                    if abs(tduration-these_srs["durations"].values[closest_index])/tduration <= duration_rel_precision_threshold: err_string_to_add += " (duration)"
+                    err_string_line2 = ""
+                    if abs(ttime-these_srs["midtimes"].values[closest_index]) >= midtime_precision_threshold:
+                        err_string_to_add += " (timestamp)"
+                        err_string_line2 += "\n\tTIMESTAMP: Expected: " + str(ttime) + " Measured: " + str(these_srs["midtimes"].values[closest_index]) + " Diff: " + str(abs(ttime-these_srs["midtimes"].values[closest_index])) + " Allowed Diff: " + str(midtime_precision_threshold)
+                    if abs(tdepth-these_srs["depths"].values[closest_index])/tdepth >= depth_rel_precision_threshold:
+                        err_string_to_add += " (depth)"
+                        err_string_line2 += "\n\tDEPTH: Expected: " + str(tdepth) + " Measured: " + str(these_srs["depths"].values[closest_index]) + " Rel. Diff: " + str(abs(tdepth-these_srs["depths"].values[closest_index])/tdepth*100.) + "% Allowed Rel. Diff: " + str(depth_rel_precision_threshold*100.)+"%"
+                    if abs(tduration-these_srs["durations"].values[closest_index])/tduration >= duration_rel_precision_threshold:
+                        err_string_to_add += " (duration)"
+                        err_string_line2 += "\n\tDURATION: Expected: " + str(tduration) + " Measured: " + str(these_srs["durations"].values[closest_index]) + " Rel. Diff: " + str(abs(tduration-these_srs["durations"].values[closest_index])/tduration*100.) + "% Allowed Rel. Diff: " + str(duration_rel_precision_threshold*100.)+"%"
                     print "   Transit {0: <3d}...FAIL".format(tnum) + err_string_to_add
+                    print err_string_line2
                     sys.exit(1)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Unit test now does correct comparison between the closest segment "event" (based on timestamp) and the expected transit parameters from the model.  Note that in both test_bls_pulse and test_bls_pulse_vec some transit events are failing due to timestamp and/or durations not being close enough to expected values.
